### PR TITLE
Update for REES paper

### DIFF
--- a/Listing.hs
+++ b/Listing.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Listing (Listing (..), listing) where
+module Listing (Listing (..), Register (..), listing) where
 
 import Microprogram
 import Control.Monad
@@ -16,9 +16,17 @@ instance Monad Listing where
       where
         Listing result ss' = f a
 
+instance Applicative Listing where
+    pure  = return
+    (<*>) =  ap
+
+instance Functor Listing where
+    fmap = (<$>)
+
 instance Microprogram Listing where
     data Register Listing = Register String
     pc = Register "pc"
+    opcode = Register "opcode"
     readMemory address = Listing 0 ["readMemory " ++ show address]
     writeMemory address value = Listing () ["writeMemory " ++ show address ++ " " ++ show value]
     readRegister (Register register) = Listing 0 ["readRegister " ++ register]

--- a/Main.hs
+++ b/Main.hs
@@ -1,25 +1,43 @@
 import Microprogram
-import Simulation
+import qualified Simulation as S
+import qualified Listing as L
 
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as Map
 
-program :: Simulation ()
-program = do
-	writeMemory 100 200
-	writeRegister (R 0) 1234
+program :: Microprogram m => Register m -> Register m -> m ()
+program reg0 reg1 = do
+    writeMemory 100 200
+    writeMemory 100 200
+    writeRegister reg0 1234
 
-	let programAddress = 10000
-	writeRegister pc programAddress
-	writeMemory (programAddress + 1) 100
-	writeMemory (programAddress + 2) 222
+    let programAddress = 10000
+    writeRegister pc programAddress
+    writeMemory (programAddress + 1) 100
+    writeMemory (programAddress + 2) 222
 
-	load (R 1)
+    load reg1
 
-processor = Processor (Map.empty) (Map.empty)
+programSimulation :: S.Simulation ()
+programSimulation =
+    program (S.R 0) (S.R 1)
+
+programListing :: L.Listing ()
+programListing =
+    program (L.Register "0") (L.Register "1")
+
+processor = S.Processor (Map.empty) (Map.empty)
 
 main = do
-	putStrLn $ "\nInitial processor:\n" ++ show processor ++ "\n"
-	let (value, newProcessor) = simulate program processor
-	putStrLn $ "Value = " ++ show value ++ "\n"
-	putStrLn $ "New processor:\n" ++ show newProcessor ++ "\n"
+    putStrLn "==============="
+    putStrLn "=== Listing ==="
+    putStrLn "==============="
+    putStrLn $ L.listing programListing
+
+    putStrLn "=================="
+    putStrLn "=== Simulation ==="
+    putStrLn "=================="
+    putStrLn $ "\nInitial processor:\n" ++ show processor ++ "\n"
+    let (value, newProcessor) = S.simulate programSimulation processor
+    putStrLn $ "Value = " ++ show value ++ "\n"
+    putStrLn $ "New processor:\n" ++ show newProcessor ++ "\n"

--- a/Simulation.hs
+++ b/Simulation.hs
@@ -24,6 +24,13 @@ instance Monad Simulation where
                             Simulation h = g a
                           in h p'
 
+instance Applicative Simulation where
+    pure  = return
+    (<*>) =  ap
+
+instance Functor Simulation where
+    fmap = (<$>)
+
 instance Microprogram Simulation where
     data Register Simulation = R Int | RegisterPC | RegisterOpcode
     pc     = RegisterPC


### PR DESCRIPTION
I've done a tiny refinement of code and added an example of `Listing` instance for `Microprogram` type class.

More specific:

1) Missing `Functor` and `Applicative` instances for `Simulation` and `Listing`
2) In `Main.hs`, `program` function now has generic type `Register -> Register -> Microprogram ()` instead of specific one tied to `Simulation`
3) `main` function now prints program listing prior to simulation

In extended REES paper, I plan to give an account of `program` function as a generic DSL code and then point out that concrete instances of `Microprogram`, i.e. `Listing` and `Simulation`, enrich this abstract code with a concrete semantics in two different ways.